### PR TITLE
Make Yooka-Laylee work as a .apworld

### DIFF
--- a/worlds/yooka_laylee/Items.py
+++ b/worlds/yooka_laylee/Items.py
@@ -1,8 +1,7 @@
 import json
-import os
+import pkgutil
 
-with open(os.path.join(os.path.dirname(__file__), 'items.json'), 'r') as file:
-    item_table = json.loads(file.read())
+item_table = json.loads(pkgutil.get_data(__name__, "items.json").decode())
 
 lookup_name_to_item = {}
 lookup_name_to_id = {}

--- a/worlds/yooka_laylee/Locations.py
+++ b/worlds/yooka_laylee/Locations.py
@@ -1,8 +1,7 @@
 import json
-import os
+import pkgutil
 
-with open(os.path.join(os.path.dirname(__file__), 'locations.json'), 'r') as file:
-    location_table = json.loads(file.read())
+location_table = json.loads(pkgutil.get_data(__name__, "locations.json").decode())
 
 lookup_name_to_id = {}
 for item in location_table:

--- a/worlds/yooka_laylee/Regions.py
+++ b/worlds/yooka_laylee/Regions.py
@@ -1,9 +1,8 @@
 import json
-import os
+import pkgutil
 from BaseClasses import Entrance
 
-with open(os.path.join(os.path.dirname(__file__), 'regions.json'), 'r') as file:
-    regionMap = json.loads(file.read())
+regionMap = json.loads(pkgutil.get_data(__name__, "regions.json").decode())
 
 def create_regions(world, player: int):
     from . import create_region


### PR DESCRIPTION
This let me zip up `worlds/yooka_laylee` as a .apworld (see https://cdn.discordapp.com/attachments/1103936661156536330/1121031084235313192/yooka_laylee.apworld) and succesfully generate a multiworld using the released 0.4.1 build of AP.